### PR TITLE
print -> instead of \u2192 for arrows

### DIFF
--- a/app.go
+++ b/app.go
@@ -735,7 +735,7 @@ func (app *App) handleIRCEvent(netID string, ev interface{}) {
 		}
 	case irc.SelfNickEvent:
 		var body ui.StyledStringBuilder
-		body.WriteString(fmt.Sprintf("%s\u2192%s", ev.FormerNick, s.Nick()))
+		body.WriteString(fmt.Sprintf("%s->%s", ev.FormerNick, s.Nick()))
 		textStyle := tcell.StyleDefault.Foreground(tcell.ColorGray)
 		arrowStyle := tcell.StyleDefault
 		body.AddStyle(0, textStyle)
@@ -1105,7 +1105,7 @@ func (app *App) formatEvent(ev irc.Event) ui.Line {
 	switch ev := ev.(type) {
 	case irc.UserNickEvent:
 		var body ui.StyledStringBuilder
-		body.WriteString(fmt.Sprintf("%s\u2192%s", ev.FormerNick, ev.User))
+		body.WriteString(fmt.Sprintf("%s->%s", ev.FormerNick, ev.User))
 		textStyle := tcell.StyleDefault.Foreground(tcell.ColorGray)
 		arrowStyle := tcell.StyleDefault
 		body.AddStyle(0, textStyle)


### PR DESCRIPTION
for some reason it's printed as 1-wide but is actually two and looks
broken